### PR TITLE
Replace sha256 with one that uses the bytes package

### DIFF
--- a/httpdiff.go
+++ b/httpdiff.go
@@ -4,7 +4,7 @@
 package main
 
 import (
-	"crypto/sha256"
+	"bytes"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -190,7 +190,7 @@ func main() {
 	if vsi(len(body[0]), len(body[1]), "Body lengths differ:") {
 		dump = true
 	} else {
-		if sha256.Sum256(body[0]) != sha256.Sum256(body[1]) {
+		if !bytes.Equal(body[0], body[1]) {
 			fmt.Printf("Bodies are different\n")
 			dump = true
 		}


### PR DESCRIPTION
This means less CPU for computing hashes, also a much better way in general to check if two byte arrays are the same or not.

Closes #8 
