### PR TITLE
add make target and instructions to build tiny docker image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ _testmain.go
 *.prof
 
 httpdiff
+
+# The version of docker on circleci does not currently support -f.
+Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,14 @@ all: ; @go build httpdiff.go
 # https://medium.com/@kelseyhightower/optimizing-docker-images-for-static-binaries-b5696e26eb07
 static: ; @GOPATH=~ CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -tags netgo -ldflags '-w' httpdiff.go
 
+.PHONY: builder
+builder: ; @./make builder
+
+.PHONY: runtime
+runtime: builder ; @./make runtime
+
 .PHONY: install
 install: ; @go install ./...
 
 .PHONY: clean
-clean: ; @rm httpdiff
+clean: ; @./make clean

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 .PHONY: all
 all: ; @go build httpdiff.go
 
+.PHONY: static
+# https://medium.com/@kelseyhightower/optimizing-docker-images-for-static-binaries-b5696e26eb07
+static: ; @GOPATH=~ CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -tags netgo -ldflags '-w' httpdiff.go
+
 .PHONY: install
 install: ; @go install ./...
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,24 @@ best results use in a terminal that supports ANSI escape sequences.
 
 # Installation
 
+If you have a full development environment:
+
 ```
 go get github.com/jgrahamc/httpdiff
 go install github.com/jgrahamc/httpdiff
+```
+
+If you are on a minimal host, such as CoreOS:
+
+```
+# Build the smallest possible docker image that
+# contains a static binary and nothing else.
+git clone https://github.com/jgrahamc/httpdiff.git
+cd httpdiff
+./make runtime
+
+# Add this line to your shell init file (e.g., .bashrc).
+alias httpdiff="docker run --rm -it -v /tmp:/tmp httpdiff"
 ```
 
 # Usage

--- a/builder.dockerfile
+++ b/builder.dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:latest
+RUN apk upgrade --update && apk add \
+    git \
+    go \
+    make \
+    && rm -fr /var/cache/apk/*
+RUN adduser -D developer
+WORKDIR /home/developer
+USER developer
+ENTRYPOINT ["make"]
+CMD ["static"]
+COPY . /home/developer

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,14 @@
+# https://circleci.com/docs/docker
+machine:
+  services:
+    - docker
+
+dependencies:
+  override:
+    - docker info
+    - ./make runtime
+    - docker images
+
+test:
+  override:
+    - ./make test

--- a/make
+++ b/make
@@ -1,0 +1,55 @@
+#!/bin/sh
+set -x
+set -e
+
+# If you are on CoreOS or similar minimal OS,
+# you do not have the `make' command.
+# This simple script compensates for that.
+#
+# Note: We use `docker cp' instead of a volume mount
+# to enable a person to build on a remote docker host.
+# Example:
+#
+#   export DOCKER_HOST='tcp://192.168.254.162:2375'
+#   ./make runtime
+
+usage() {
+  echo 'Usage: ./make [builder|runtime|clean]' >&2
+  exit 1
+}
+
+builder() {
+  cp -f builder.dockerfile Dockerfile
+  docker build -t httpdiff_builder .
+}
+
+runtime() {
+  docker images | grep httpdiff_builder || builder
+  docker rm -f builder &> /dev/null || :
+  docker run --name builder httpdiff_builder
+  docker cp builder:/home/developer/httpdiff .
+  cp -f runtime.dockerfile Dockerfile
+  docker build -t httpdiff .
+  docker images | grep -e SIZE -e httpdiff
+}
+
+clean() {
+  rm httpdiff
+  docker rm -f httpdiff_builder
+  docker rmi -f httpdiff_builder
+  docker rmi -f httpdiff
+  docker images | awk '/<none>/ {print $3}' | xargs docker rmi
+}
+
+test() {
+  # The image uses `-help' as the default option.
+  # It exits 0 (good) if the `-help' works and non-zero otherwise.
+  # Therefore we do not need to grep output.
+  docker run -it -v /tmp:/tmp httpdiff
+}
+
+main() {
+  [ "x${1}" = "x" ] && usage || ${1}
+}
+
+main ${1}

--- a/runtime.dockerfile
+++ b/runtime.dockerfile
@@ -1,0 +1,4 @@
+FROM scratch
+COPY httpdiff /
+ENTRYPOINT ["/httpdiff"]
+CMD ["-help"]


### PR DESCRIPTION
Build a static binary for httpdiff, then create the smallest
possible docker image to hold it. This uses an intermediate
"builder" container to compile the binary as an unprivileged
user, then creates a "runtime" image to hold the binary.

Add config to build and test the image on CircleCI.
